### PR TITLE
Support custom `payment_method_types` from the client, add grabpay

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -408,7 +408,7 @@ def payment_methods_for_country(country)
   when 'mx'
     %w[card oxxo]
   when 'my'
-    %w[card fpx]
+    %w[card fpx grabpay]
   when 'nl'
     %w[card ideal sepa_debit sofort]
   when 'au'
@@ -426,7 +426,7 @@ def payment_methods_for_country(country)
   when 'at'
     %w[card paypal sofort eps]
   when 'sg'
-    %w[card alipay]
+    %w[card alipay grabpay]
   when 'in'
     %w[card upi netbanking]
   else

--- a/web.rb
+++ b/web.rb
@@ -216,6 +216,8 @@ post '/create_payment_intent' do
       payload = Sinatra::IndifferentHash[JSON.parse(request.body.read)]
   end
 
+  supported_payment_methods = payload[:supported_payment_methods] ? payload[:supported_payment_methods].split(",") : nil
+
   # Calculate how much to charge the customer
   amount = calculate_price(payload[:products], payload[:shipping])
 
@@ -226,7 +228,7 @@ post '/create_payment_intent' do
       :customer => payload[:customer_id] || @customer.id,
       :description => "Example PaymentIntent",
       :capture_method => ENV['CAPTURE_METHOD'] == "manual" ? "manual" : "automatic",
-      payment_method_types: payment_methods_for_country(payload[:country]),
+      payment_method_types: supported_payment_methods ? supported_payment_methods : payment_methods_for_country(payload[:country]),
       :metadata => {
         :order_id => '5278735C-1F40-407D-933A-286E463E72D8',
       }.merge(payload[:metadata] || {}),


### PR DESCRIPTION
1/ Passing a comma separated `supported_payment_methods` parameter from the client allows overriding the country<>payment_method config in `payment_methods_for_country()`

e.g. the client can pass `supported_payment_methods=card,afterpay_clearpay` to set custom `payment_method_types` when creating a PaymentIntent

2/ Also added `grabpay` as a payment method to `sg` and `my` according to https://stripe.com/docs/payments/grabpay