### PR TITLE
Set heroku stack to 18

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,5 +8,6 @@
       "description": "Find this at https://dashboard.stripe.com/account/apikeys (it'll look like sk_test_****)",
       "required": true
     }
-  }
+  },
+  "stack": "heroku-18"
 }


### PR DESCRIPTION
Using the "Deploy to Heroku" button errors due to Heroku defaulting to the latest stack, which doesn't support Ruby 2.6.3:

```
-----> Building on the Heroku-20 stack
-----> Ruby app detected
-----> Installing bundler 1.17.3
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rack
Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.3.tgz -s -o - | tar zxf - ' failed on attempt 1 of 3.
Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.3.tgz -s -o - | tar zxf - ' failed on attempt 2 of 3.
!
! The Ruby version you are trying to install does not exist on this stack.
!
! You are trying to install ruby-2.6.3 on heroku-20.
!
! Ruby ruby-2.6.3 is present on the following stacks:
!
! - cedar-14
! - heroku-16
! - heroku-18
!
! Heroku recommends you use the latest supported Ruby version listed here:
! https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
!
! For more information on syntax for declaring a Ruby version see:
! https://devcenter.heroku.com/articles/ruby-versions
!
! Push rejected, failed to compile Ruby app.
! Push failed
```

This hardcodes the stack to `heroku-18`, which does support Ruby 2.6.3.